### PR TITLE
Removed 'Object' type from the Stage 'canvas' property.

### DIFF
--- a/easeljs/easeljs.d.ts
+++ b/easeljs/easeljs.d.ts
@@ -875,11 +875,11 @@ declare namespace createjs {
         }
 
     export class Stage extends Container {
-        constructor(canvas: HTMLCanvasElement | string | Object);
+        constructor(canvas: HTMLCanvasElement | string);
 
         // properties
         autoClear: boolean;
-        canvas: HTMLCanvasElement | Object;
+        canvas: HTMLCanvasElement;
         drawRect: Rectangle;
         handleEvent: Function;
         mouseInBounds: boolean;


### PR DESCRIPTION
case 1. Add a new type definition.
- [ ] checked compilation succeeds with `--target es6` and `--noImplicitAny` options.
- [ ] has correct [naming convention](http://definitelytyped.org/guides/contributing.html#naming-the-file)
- [ ] has a [test file](http://definitelytyped.org/guides/contributing.html#tests) with the suffix of  `-tests.ts` or `-tests.tsx`.

case 2. Improvement to existing type definition.
- documentation or source code reference which provides context for the suggested changes.  url http://api.jquery.com/html .
  - it has been reviewed by a DefinitelyTyped member.

